### PR TITLE
use CONTRIBUTING.md link from github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ Looking for a Hacktoberfest issue? 👉 <https://github.com/search?utf8=✓&q=la
 
 Looking for a good first issue? 👉 <https://github.com/search?utf8=✓&q=label%3A"good+first+issue"&type=Issues> or go to [Up For Grabs](https://up-for-grabs.net/#/).
 
-Know of another hacktoberfest swag opportunity? Send a [pull request](https://github.com/benbarth/hacktoberfest-swag/pulls)! (Don't forget to review our [contribution guidelines](CONTRIBUTING.md).)
+Know of another hacktoberfest swag opportunity? Send a [pull request](https://github.com/benbarth/hacktoberfest-swag/pulls)! (Don't forget to review our [contribution guidelines](https://github.com/benbarth/hacktoberfest-swag/blob/master/CONTRIBUTING.md).)


### PR DESCRIPTION
Fix for #134. It doesn't generate the theme for the link, but instead points directly to the repository. I figured it's all right, since the user willing to contribute should be familiar with Github.