### PR TITLE
Remove lakeFS

### DIFF
--- a/participants/2020/lakefs.yml
+++ b/participants/2020/lakefs.yml
@@ -1,8 +1,0 @@
----
-Name: lakeFS
-Website: https://lakefs.io
-Swag:
-  - stickers
-  - shirt
-Description: "1 PR on our GitHub repo for a collection of stickers, 2 or more gets stickers and a lakeFS t-shirt 👕"
-Details: https://docs.lakefs.io/contributing#get-ready-for-hacktoberfest


### PR DESCRIPTION
@YaelRiv works for lakesFS (see https://dev.to/yaelriv/comment/1573h) and added lakeFS to the repo in https://github.com/benbarth/hacktoberfest-swag/pull/110.

However, they've received lots of spam and requested to be removed in https://github.com/benbarth/hacktoberfest-swag/pull/132.

That PR updated the wrong file. This removes the YML file instead.

---

Unfortunately, it seems spam is much, much worse this year:

* https://blog.domenic.me/hacktoberfest/
* https://twitter.com/shitoberfest
