### PR TITLE
Include update from DigitslOcean to prevent spam

### DIFF
--- a/participants/hacktoberfest.yml
+++ b/participants/hacktoberfest.yml
@@ -4,6 +4,6 @@ Website: https://www.digitalocean.com
 Swag:
   - stickers
   - shirt
-Description: "Four pull requests to any public repo on GitHub. Support open source and pick a limited edition T-shirt or plant a tree."
-Details: https://hacktoberfest.digitalocean.com/
+Description: "Four pull requests to any participating public repo on GitHub. Support open source and pick a limited edition T-shirt or plant a tree.  To reduce spam DigitalOcean introduced new measures on October, 3rd: PRs count only if: **Submitted in a repo with the hacktoberfest topic AND during the month of October AND (The PR is merged OR The PR is labelled as hacktoberfest-accepted by a maintainer OR The PR has been approved)**"
+Details: https://hacktoberfest.digitalocean.com/hacktoberfest-update
 IsSponsor: True


### PR DESCRIPTION
An update from DigitslOcean on efforts to reduce spam with Hacktoberfest: introducing maintainer opt-in and more

- [x] I've read the [Contributing.md](../blob/master/CONTRIBUTING.md) file
- [x] I do not intend to make low-value changes, just for swag. I am aware, that my PR could otherwise be flagged as `spam` or `invalid` and may lead to a permanent exclusion from the Hacktoberfest event.

### Adding a new Hacktoberfest participant

- [ ] I did not edit the README.md file by hand
- [ ] I made sure, that the new participant has not already been added
- [ ] I'm not adding a company from the [blocklist](../blob/master/.gitignore)

### Editing an existing Hacktoberfest participant

- [x] I did not edit the README.md file by hand
- [x] I made proper changes to the existing participant.yml file
